### PR TITLE
Specify websockets and aiohttp versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ pymongo==3.8.0
 setuptools==40.8.0
 async-timeout==3.0.1
 schedule==0.6.0
-aiohttp
-websockets
+aiohttp>=3.6.0,<3.7.0
+websockets>=6.0,!=7.0,!=8.0,!=8.0.1,<9.0
 chardet
 pytest
 mock


### PR DESCRIPTION
Discord.py is only compatible with specific versions of aiohttp and websockets versions. For example, when using a websockets version not supported, the following crash will occur occasionally:
`TypeError: close_connection() got an unexpected keyword argument 'force'`